### PR TITLE
Revise conflict resolution for non-participation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -66,9 +66,10 @@ All members will treat one another with respect and professionalism. We value di
 ## Conflict Resolution & Non-Participation
 - Issues should be addressed early and respectfully within the team.
 - If a member becomes inactive:
-    - A check-in message will be sent
-    - Tasks may be reassigned if necessary
-    - The issue may be escalated to the module tutor if it remains unresolved
+    - A private check-in will be made to understand the reason for non-participation.
+    - Tasks will be reassigned if necessary to avoid delays.
+    - A formal warning will be issued if inactivity continues.
+    - If non-participation occurs three consecutive times, the member will be removed from the group and the issue will be reported to the module lecturer
 
 
 


### PR DESCRIPTION
Updated conflict resolution process for inactive members.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Code of Conduct with a revised Conflict Resolution & Non-Participation section that clarifies the handling of inactivity. The new escalation process includes private check-ins to understand non-participation reasons, formal warnings for continued inactivity, and a three-strikes policy resulting in member removal and escalation to the module lecturer for persistent issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->